### PR TITLE
Use official Jekyll image, for longevity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.4'
 
 services:
   jekyll:
-    image: jekyll/jekyll:latest
+    image: jekyll/jekyll:4.0
     volumes:
       - .:/srv/jekyll
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,9 @@ version: '2.4'
 
 services:
   jekyll:
-    image: bretfisher/jekyll-serve
+    image: jekyll/jekyll:latest
     volumes:
-      - .:/site
+      - .:/srv/jekyll
     ports:
       - '4000:4000'
+    command: jekyll serve --watch


### PR DESCRIPTION
Proposing this switch to the official docker image for Jekyll, in case bretfisher stops maintaining his image. This docker-compose file still allows for live updates to the running site as you work on it.